### PR TITLE
Modified the estimation phase.

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -149,15 +149,14 @@ def setup_jax(device="cpu"):
         os.environ.update(JAX_PLATFORM_NAME=device)
 
     import jax
-    from jax.config import config
 
     if device == "tpu":
-        config.update("jax_xla_backend", "tpu_driver")
-        config.update("jax_backend_target", os.environ.get("JAX_BACKEND_TARGET"))
+        jax.config.update("jax_xla_backend", "tpu_driver")
+        jax.config.update("jax_backend_target", os.environ.get("JAX_BACKEND_TARGET"))
 
     if device != "tpu":
         # use 64 bit floats (not supported on TPU)
-        config.update("jax_enable_x64", True)
+        jax.config.update("jax_enable_x64", True)
 
     if device == "gpu":
         assert len(jax.devices()) > 0

--- a/run.py
+++ b/run.py
@@ -143,12 +143,11 @@ def main(benchmark, size=None, backend=None, repetitions=None, burnin=1, device=
 
         for b, s in runs:
             # use end-to-end runtime for repetition estimation
-            def run_func():
+            with setup_functions[b](device=device):
                 run = bm_module.get_callable(b, s, device=device)
-                with setup_functions[b](device=device):
+                def run_func():
                     run()
-
-            repetitions[(b, s)] = estimate_repetitions(run_func)
+                repetitions[(b, s)] = estimate_repetitions(run_func)
     else:
         repetitions = {(b, s): repetitions for b, s in runs}
 

--- a/run.py
+++ b/run.py
@@ -145,9 +145,7 @@ def main(benchmark, size=None, backend=None, repetitions=None, burnin=1, device=
             # use end-to-end runtime for repetition estimation
             with setup_functions[b](device=device):
                 run = bm_module.get_callable(b, s, device=device)
-                def run_func():
-                    run()
-                repetitions[(b, s)] = estimate_repetitions(run_func)
+                repetitions[(b, s)] = estimate_repetitions(run)
     else:
         repetitions = {(b, s): repetitions for b, s in runs}
 


### PR DESCRIPTION
For running the estimation phase (how many iterations are performed) the `get_callback()` function was not called with an activated setup context. this is different from the actual measuring loop, where `get_callback()` was called within the setup context. This might lead to different behaviours.
This commit makes sure that the estimation takes place under an activated setup context.